### PR TITLE
feat(krn): implement Kopexa Resource Name (KRN) system with JSON/YAML support and database integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	entgo.io/ent v0.14.4
+	github.com/goccy/go-yaml v1.17.1
 	github.com/google/uuid v1.6.0
 	github.com/muesli/termenv v0.16.0
 	github.com/nats-io/nats-server/v2 v2.11.3

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-tpm v0.9.3 h1:+yx0/anQuGzi+ssRqeD6WpXjW2L/V0dItUayO0i9sRc=
 github.com/google/go-tpm v0.9.3/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=

--- a/krn/README.md
+++ b/krn/README.md
@@ -1,0 +1,121 @@
+# Kopexa Resource Name (KRN)
+
+The KRN package implements a standardized resource naming system for the Kopexa platform, following Google's resource naming design principles. It provides a consistent way to identify and reference resources across different services.
+
+## Features
+
+- Canonical resource naming format: `//<service-name>/<relative-resource-name>`
+- Support for JSON and YAML serialization
+- Database integration via `sql.Scanner` and `driver.Valuer`
+- Legacy format support
+- Resource ID validation
+- Comprehensive test coverage
+
+## Installation
+
+```bash
+go get github.com/kopexa-grc/common/krn
+```
+
+## Usage
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/kopexa-grc/common/krn"
+)
+
+func main() {
+    // Create a new KRN
+    krn, err := krn.New("//kopexa.com/frameworks/iso-27001-2022")
+    if err != nil {
+        panic(err)
+    }
+
+    // Get the service name
+    fmt.Println(krn.ServiceName) // Output: kopexa.com
+
+    // Get the resource path
+    fmt.Println(krn.RelativeResourceName) // Output: frameworks/iso-27001-2022
+
+    // Get the canonical string representation
+    fmt.Println(krn.String()) // Output: //kopexa.com/frameworks/iso-27001-2022
+}
+```
+
+### Working with Resource IDs
+
+```go
+// Get a resource ID from a collection
+resourceID, err := krn.ResourceID("frameworks")
+if err != nil {
+    panic(err)
+}
+fmt.Println(resourceID) // Output: iso-27001-2022
+
+// Create a child KRN
+childKRN, err := krn.NewChildKRN(
+    "//kopexa.com/frameworks/iso-27001-2022",
+    "controls",
+    "a.1.1",
+)
+if err != nil {
+    panic(err)
+}
+fmt.Println(childKRN.String()) // Output: //kopexa.com/frameworks/iso-27001-2022/controls/a.1.1
+```
+
+### Database Integration
+
+```go
+// The KRN type implements sql.Scanner and driver.Valuer
+type Resource struct {
+    ID   int
+    KRN  krn.KRN
+    Name string
+}
+
+// Can be used directly in database operations
+db.QueryRow("SELECT id, krn, name FROM resources WHERE id = ?", 1).Scan(&resource.ID, &resource.KRN, &resource.Name)
+```
+
+### JSON/YAML Support
+
+```go
+// Marshal to JSON
+data, err := json.Marshal(krn)
+if err != nil {
+    panic(err)
+}
+fmt.Println(string(data)) // Output: "//kopexa.com/frameworks/iso-27001-2022"
+
+// Unmarshal from JSON
+var newKRN krn.KRN
+err = json.Unmarshal(data, &newKRN)
+if err != nil {
+    panic(err)
+}
+```
+
+## Resource ID Format
+
+Resource IDs must follow these rules:
+- 4-200 characters long
+- Contains only lowercase letters, digits, dots, or hyphens
+- Example: `1.1.2-tmp-configured`
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the BUSL-1.1 License - see the LICENSE file for details. 

--- a/krn/krn.go
+++ b/krn/krn.go
@@ -1,0 +1,320 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package krn implements the Kopexa Resource Name (KRN) system, following Google's resource naming design.
+// KRN provides a standardized way to identify and reference resources across the Kopexa platform.
+//
+// Key features:
+//   - Canonical resource naming format: //<service-name>/<relative-resource-name>
+//   - Support for JSON and YAML serialization
+//   - Database integration via sql.Scanner and driver.Valuer
+//   - Legacy format support
+//   - Resource ID validation
+//
+// Example usage:
+//
+//	krn, err := krn.New("//kopexa.com/frameworks/iso-27001-2022")
+//	if err != nil {
+//	    // handle error
+//	}
+package krn
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Common errors
+var (
+	ErrInvalidKRNFormat         = errors.New("invalid KRN format")
+	ErrInvalidResourceID        = errors.New("invalid resource ID")
+	ErrInvalidCollectionID      = errors.New("invalid collection ID")
+	ErrCollectionNotFound       = errors.New("collection not found")
+	ErrUnsupportedType          = errors.New("unsupported type")
+	ErrMissingResourcePath      = errors.New("missing relative resource path")
+	ErrInvalidLegacyFormat      = errors.New("invalid legacy KRN format")
+	ErrMustStartWithDoubleSlash = errors.New("KRN must start with //")
+)
+
+const (
+	// PathSeparator is the character used to separate path components
+	PathSeparator = "/"
+	// MinPathComponents is the minimum number of components in a valid KRN path
+	MinPathComponents = 2
+)
+
+// ServiceID extracts the service identifier from a full service name by removing the base domain.
+// Example: ServiceID("service.example.com", ".example.com") returns "service"
+func ServiceID(serviceName string, baseDomain string) string {
+	return strings.TrimSuffix(serviceName, baseDomain)
+}
+
+// IsValid checks if a string is a valid KRN format.
+// It verifies that the string can be parsed as a URL and has no scheme, fragment, or query parameters.
+func IsValid(krn string) bool {
+	x, err := url.Parse(krn)
+	if err != nil {
+		return false
+	}
+
+	return x.Scheme == "" && x.Fragment == "" && x.RawQuery == ""
+}
+
+// KRN represents a Kopexa Resource Name following Google's resource naming design.
+// See https://cloud.google.com/apis/design/resource_names for more details.
+//
+// Format: //<service-name>/<relative-resource-name>
+// Example: //kopexa.com/frameworks/iso-27001-2022
+type KRN struct {
+	ServiceName          string // The service identifier (e.g., "kopexa.com")
+	RelativeResourceName string // The resource path (e.g., "frameworks/iso-27001-2022")
+}
+
+// New creates a new KRN instance from a full resource name string.
+// Returns an error if the input string is not a valid KRN format.
+func New(fullResourceName string) (*KRN, error) {
+	u, err := url.Parse(fullResourceName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KRN format: %w", err)
+	}
+
+	path := strings.TrimLeft(u.EscapedPath(), "/")
+
+	return &KRN{
+		ServiceName:          u.Host,
+		RelativeResourceName: path,
+	}, nil
+}
+
+// MustNew creates a new KRN instance and panics if the input is invalid.
+// This should only be used for constants and tests.
+func MustNew(fullResourceName string) *KRN {
+	krn, err := New(fullResourceName)
+	if err != nil {
+		panic(err)
+	}
+
+	return krn
+}
+
+// NewChildKRN creates a new KRN as a child of an existing KRN.
+// The resource and resourceID are appended to the parent's path.
+// Returns an error if the resourceID is invalid or if the parent KRN is invalid.
+func NewChildKRN(ownerKRN string, resource string, resourceID string) (*KRN, error) {
+	if !isValidResourceID(resourceID) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidResourceID, resourceID)
+	}
+
+	krn, err := New(ownerKRN)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidKRNFormat, err)
+	}
+
+	krn.RelativeResourceName = path.Join(krn.RelativeResourceName, resource, resourceID)
+
+	return krn, nil
+}
+
+// String returns the canonical string representation of the KRN.
+func (krn *KRN) String() string {
+	return "//" + krn.ServiceName + "/" + krn.RelativeResourceName
+}
+
+// CollectionName returns the top-level collection name from the resource path.
+// Example: for "frameworks/iso-27001", returns "frameworks"
+func (krn *KRN) CollectionName() string {
+	parts := strings.Split(krn.RelativeResourceName, "/")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+
+	return ""
+}
+
+// Parse parses a canonical KRN string into a KRN struct.
+// The input must start with "//" and contain a service name and resource path.
+func Parse(input string) (KRN, error) {
+	if !strings.HasPrefix(input, "//") {
+		return KRN{}, ErrMustStartWithDoubleSlash
+	}
+
+	trimmed := strings.TrimPrefix(input, "//")
+
+	parts := strings.SplitN(trimmed, PathSeparator, MinPathComponents)
+	if len(parts) != MinPathComponents {
+		return KRN{}, ErrMissingResourcePath
+	}
+
+	return KRN{
+		ServiceName:          parts[0],
+		RelativeResourceName: parts[1],
+	}, nil
+}
+
+// MustParse parses a KRN string and panics if the input is invalid.
+// This should only be used for constants and tests.
+func MustParse(input string) KRN {
+	krn, err := Parse(input)
+	if err != nil {
+		panic(err)
+	}
+
+	return krn
+}
+
+// ParseLegacy parses a legacy KRN format that may not include the "//" prefix.
+// If the input starts with "//", it is treated as a canonical KRN.
+func ParseLegacy(input string) (KRN, error) {
+	if strings.HasPrefix(input, "//") {
+		return Parse(input)
+	}
+
+	parts := strings.SplitN(input, PathSeparator, MinPathComponents)
+	if len(parts) != MinPathComponents {
+		return KRN{}, ErrInvalidLegacyFormat
+	}
+
+	return KRN{
+		ServiceName:          parts[0],
+		RelativeResourceName: parts[1],
+	}, nil
+}
+
+// IsZero returns true if the KRN is empty (has no service name or resource path).
+func (krn KRN) IsZero() bool {
+	return krn.ServiceName == "" || krn.RelativeResourceName == ""
+}
+
+// Basename returns the last component of the resource path.
+// Example: for "frameworks/iso-27001", returns "iso-27001"
+func (krn *KRN) Basename() string {
+	keyValues := strings.Split(krn.RelativeResourceName, "/")
+	if len(keyValues) == 0 {
+		return ""
+	}
+
+	return keyValues[len(keyValues)-1]
+}
+
+// ResourceID returns the value associated with a collection ID in the resource path.
+// The collection ID and its value must be adjacent in the path.
+// Returns an error if the collection ID is not found or if the path is malformed.
+func (krn *KRN) ResourceID(collectionID string) (string, error) {
+	keyValues := strings.Split(krn.RelativeResourceName, PathSeparator)
+	for i := 0; i < len(keyValues); i += 2 {
+		if keyValues[i] == collectionID {
+			if i+1 < len(keyValues) {
+				return keyValues[i+1], nil
+			}
+
+			return "", fmt.Errorf("%w: %s", ErrInvalidCollectionID, krn.String())
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrCollectionNotFound, collectionID)
+}
+
+// Equals compares the KRN with another resource string for equality.
+// Returns true if both represent the same resource.
+func (krn *KRN) Equals(resource string) bool {
+	parsed, err := New(resource)
+	if err != nil {
+		return false
+	}
+
+	return parsed.ServiceName == krn.ServiceName && parsed.RelativeResourceName == krn.RelativeResourceName
+}
+
+// reResourceID defines the pattern for valid resource IDs:
+// - 4-200 characters long
+// - Contains only lowercase letters, digits, dots, or hyphens
+// - Example: "1.1.2-tmp-configured"
+var reResourceID = regexp.MustCompile(`^([\d-_\.]|[a-zA-Z]){4,200}$`)
+
+// isValidResourceID checks if a string matches the resource ID pattern.
+func isValidResourceID(id string) bool {
+	return reResourceID.MatchString(id)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (krn KRN) MarshalJSON() ([]byte, error) {
+	return json.Marshal(krn.String())
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (krn *KRN) UnmarshalJSON(data []byte) error {
+	var krnStr string
+	if err := json.Unmarshal(data, &krnStr); err != nil {
+		return fmt.Errorf("KRN must be a string: %w", err)
+	}
+
+	parsed, err := Parse(krnStr)
+	if err != nil {
+		return fmt.Errorf("invalid KRN format: %w", err)
+	}
+
+	*krn = parsed
+
+	return nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (krn *KRN) UnmarshalYAML(data []byte) error {
+	var krnStr string
+	if err := yaml.Unmarshal(data, &krnStr); err != nil {
+		return fmt.Errorf("KRN must be a string in YAML: %w", err)
+	}
+
+	parsed, err := Parse(krnStr)
+	if err != nil {
+		return fmt.Errorf("invalid KRN format in YAML: %w", err)
+	}
+
+	*krn = parsed
+
+	return nil
+}
+
+// Scan implements the sql.Scanner interface for database integration.
+func (krn *KRN) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var str string
+	switch v := value.(type) {
+	case string:
+		str = v
+	case []byte:
+		str = string(v)
+	default:
+		return fmt.Errorf("%w: %T", ErrUnsupportedType, value)
+	}
+
+	// Handle legacy KRN without leading //
+	if !strings.HasPrefix(str, "//") {
+		str = "//" + str
+	}
+
+	parsed, err := Parse(str)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidKRNFormat, err)
+	}
+
+	*krn = parsed
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface for database integration.
+func (krn KRN) Value() (driver.Value, error) {
+	return krn.String(), nil
+}

--- a/krn/krn_test.go
+++ b/krn/krn_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package krn
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKrnParser(t *testing.T) {
+	var krn *KRN
+
+	var err error
+
+	fullResourceName := "//service.example.com/key1/:value1:/key2/:value2:/key3/:value3:"
+	krn, err = New(fullResourceName)
+	assert.Nil(t, err)
+	assert.Equal(t, "service.example.com", krn.ServiceName)
+	assert.Equal(t, "service", ServiceID(krn.ServiceName, ".example.com"))
+	assert.Equal(t, "key1/:value1:/key2/:value2:/key3/:value3:", krn.RelativeResourceName)
+	assert.Equal(t, fullResourceName, krn.String())
+}
+
+func TestCollectionID(t *testing.T) {
+	fullResourceName := "//service.example.com/key1/:value1:/key2/:value2:/key3/:value3:"
+	krn, err := New(fullResourceName)
+	assert.Nil(t, err)
+
+	space, err := krn.ResourceID("key1")
+	require.NoError(t, err)
+	assert.Equal(t, ":value1:", space)
+
+	region, err := krn.ResourceID("key2")
+	require.NoError(t, err)
+	assert.Equal(t, ":value2:", region)
+
+	asset, err := krn.ResourceID("key3")
+	require.NoError(t, err)
+	assert.Equal(t, ":value3:", asset)
+}
+
+func TestEquals(t *testing.T) {
+	fullResourceName := "//service.example.com/key1/:value1:/key2/:value2:/key3/:value3:"
+	krn, err := New(fullResourceName)
+	require.NoError(t, err)
+	assert.True(t, krn.Equals(fullResourceName))
+
+	krn, err = New("//service.example.com/key1/:value1:/key2/:value2:/key3/:value4:")
+	require.NoError(t, err)
+	assert.False(t, krn.Equals(fullResourceName))
+}
+
+func TestKrnToPropertyName(t *testing.T) {
+	krn, err := New("//policy.api.kopexa.com/bundle/M%2FVSHZaChL8=/queries/sshdCiphers")
+	require.NoError(t, err)
+
+	res, err := krn.ResourceID("queries")
+	require.NoError(t, err)
+	assert.Equal(t, "sshdCiphers", res)
+
+	res, err = krn.ResourceID("nothere")
+	assert.Error(t, err)
+	assert.Equal(t, "", res)
+}
+
+// NewDataCategoryKRN generates a KRN for a data category using only spaceID and a UUID.
+func newDataCategoryKRN(spaceID string) KRN {
+	id := uuid.New().String()
+	resourceID := fmt.Sprintf("%s-%s", spaceID, id)
+
+	return KRN{
+		ServiceName:          "kopexa.com",
+		RelativeResourceName: fmt.Sprintf("data-categories/%s", resourceID),
+	}
+}
+
+func TestDataCategoryKRN(t *testing.T) {
+	spaceID := "space-123"
+	krn := newDataCategoryKRN(spaceID)
+
+	assert.Equal(t, "kopexa.com", krn.ServiceName)
+	assert.Contains(t, krn.RelativeResourceName, "data-categories/")
+	assert.Contains(t, krn.RelativeResourceName, spaceID)
+
+	// Prüfe Format: "data-categories/space-123-..."
+	parts := strings.Split(krn.RelativeResourceName, "/")
+	assert.Equal(t, "data-categories", parts[0])
+	assert.True(t, strings.HasPrefix(parts[1], spaceID+"-"))
+
+	// JSON roundtrip
+	jsonData, err := json.Marshal(krn)
+	require.NoError(t, err)
+
+	var parsed KRN
+	err = json.Unmarshal(jsonData, &parsed)
+	require.NoError(t, err)
+
+	assert.True(t, parsed.Equals(krn.String()))
+}
+
+func TestKRN_UnmarshalYAML(t *testing.T) {
+	var target struct {
+		Ref struct {
+			KRN KRN `yaml:"krn"`
+		} `yaml:"controlRefs"`
+	}
+
+	yamlData := []byte(`controlRefs:
+  krn: "//kopexa.com/frameworks/iso-27001-2022"`)
+
+	err := yaml.Unmarshal(yamlData, &target)
+	require.NoError(t, err)
+	assert.Equal(t, "kopexa.com", target.Ref.KRN.ServiceName)
+	assert.Equal(t, "frameworks/iso-27001-2022", target.Ref.KRN.RelativeResourceName)
+}
+
+func TestNewChildKRN(t *testing.T) {
+	type args struct {
+		ownerKRN   string
+		resource   string
+		resourceID string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *KRN
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			args: args{
+				ownerKRN:   "//kopexa.com",
+				resource:   "checks",
+				resourceID: "123e4567-e89b-12d3-a456-426614174000",
+			},
+			want: &KRN{
+				ServiceName:          "kopexa.com",
+				RelativeResourceName: "checks/123e4567-e89b-12d3-a456-426614174000",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewChildKRN(tt.args.ownerKRN, tt.args.resource, tt.args.resourceID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewChildKRN() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewChildKRN() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	assert.True(t, IsValid("//kopexa.com/frameworks/iso-27001-2022"))
+	assert.False(t, IsValid("http://kopexa.com/frameworks/iso-27001-2022"))
+	assert.False(t, IsValid(":invalid:krn"))
+}
+
+func TestMustNewAndMustParse(t *testing.T) {
+	// MustNew should not panic for valid input
+	assert.NotPanics(t, func() {
+		krn := MustNew("//kopexa.com/frameworks/iso-27001-2022")
+		assert.Equal(t, "kopexa.com", krn.ServiceName)
+	})
+	// MustNew should panic for invalid input
+	assert.Panics(t, func() {
+		_ = MustNew(":invalid:krn")
+	})
+
+	// MustParse should not panic for valid input
+	assert.NotPanics(t, func() {
+		krn := MustParse("//kopexa.com/frameworks/iso-27001-2022")
+		assert.Equal(t, "kopexa.com", krn.ServiceName)
+	})
+	// MustParse should panic for invalid input
+	assert.Panics(t, func() {
+		_ = MustParse(":invalid:krn")
+	})
+}
+
+func TestParseLegacy(t *testing.T) {
+	krn, err := ParseLegacy("kopexa.com/frameworks/iso-27001-2022")
+	assert.NoError(t, err)
+	assert.Equal(t, "kopexa.com", krn.ServiceName)
+	assert.Equal(t, "frameworks/iso-27001-2022", krn.RelativeResourceName)
+
+	krn2, err := ParseLegacy("//kopexa.com/frameworks/iso-27001-2022")
+	assert.NoError(t, err)
+	assert.Equal(t, krn, krn2)
+
+	_, err = ParseLegacy(":invalid")
+	assert.Error(t, err)
+}
+
+func TestIsZero(t *testing.T) {
+	assert.True(t, KRN{}.IsZero())
+	assert.True(t, KRN{ServiceName: ""}.IsZero())
+	assert.True(t, KRN{RelativeResourceName: ""}.IsZero())
+	assert.False(t, KRN{ServiceName: "foo", RelativeResourceName: "bar"}.IsZero())
+}
+
+func TestBasenameAndCollectionName(t *testing.T) {
+	krn := MustNew("//kopexa.com/frameworks/iso-27001-2022")
+	assert.Equal(t, "iso-27001-2022", krn.Basename())
+	assert.Equal(t, "frameworks", krn.CollectionName())
+
+	krn2 := MustNew("//kopexa.com/")
+	assert.Equal(t, "", krn2.Basename())
+	assert.Equal(t, "", krn2.CollectionName())
+}
+
+func TestScanAndValue(t *testing.T) {
+	krn := MustNew("//kopexa.com/frameworks/iso-27001-2022")
+	var scanKRN KRN
+	// Scan from string
+	err := scanKRN.Scan("//kopexa.com/frameworks/iso-27001-2022")
+	assert.NoError(t, err)
+	assert.Equal(t, krn, &scanKRN)
+	// Scan from []byte
+	err = scanKRN.Scan([]byte("//kopexa.com/frameworks/iso-27001-2022"))
+	assert.NoError(t, err)
+	assert.Equal(t, krn, &scanKRN)
+	// Scan from legacy string
+	err = scanKRN.Scan("kopexa.com/frameworks/iso-27001-2022")
+	assert.NoError(t, err)
+	assert.Equal(t, krn, &scanKRN)
+	// Scan from unsupported type
+	err = scanKRN.Scan(123)
+	assert.Error(t, err)
+	// Value
+	val, err := krn.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, "//kopexa.com/frameworks/iso-27001-2022", val)
+}


### PR DESCRIPTION
- Added KRN struct and methods for creating, parsing, and validating resource names.
- Implemented support for JSON and YAML serialization.
- Introduced database integration via sql.Scanner and driver.Valuer.
- Added comprehensive unit tests for KRN functionality.
- Updated go.mod to include the goccy/go-yaml dependency.
- Created README.md to document the KRN package and its features.