### PR TITLE
feat(parser): add query parameter parsing functions with unit tests

### DIFF
--- a/khttp/parser/parser.go
+++ b/khttp/parser/parser.go
@@ -1,0 +1,49 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package parser
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// ParseQueryInt parses an integer from a query parameter, returning a default value if parsing fails.
+func ParseQueryInt(r *http.Request, key string, defaultValue int) int {
+	value := r.URL.Query().Get(key)
+	if value == "" {
+		return defaultValue
+	}
+
+	return parseIntOrDefault(value, defaultValue)
+}
+
+// parseIntOrDefault converts a string to an int, returning a default value if parsing fails.
+func parseIntOrDefault(value string, defaultValue int) int {
+	if value == "" {
+		return defaultValue
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+
+	return parsed
+}
+
+// ParseTimeParam parses a time parameter in RFC3339 format
+func ParseTimeParam(r *http.Request, key string) *time.Time {
+	param := r.URL.Query().Get(key)
+	if param == "" {
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339, param)
+	if err != nil {
+		return nil
+	}
+
+	return &t
+}

--- a/khttp/parser/parser_test.go
+++ b/khttp/parser/parser_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package parser
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseQueryInt(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		key          string
+		defaultValue int
+		expected     int
+	}{
+		{
+			name:         "valid integer",
+			query:        "value=42",
+			key:          "value",
+			defaultValue: 0,
+			expected:     42,
+		},
+		{
+			name:         "invalid integer",
+			query:        "value=invalid",
+			key:          "value",
+			defaultValue: 0,
+			expected:     0,
+		},
+		{
+			name:         "missing key",
+			query:        "other=42",
+			key:          "value",
+			defaultValue: 0,
+			expected:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{
+				URL: &url.URL{
+					RawQuery: tt.query,
+				},
+			}
+			result := ParseQueryInt(req, tt.key, tt.defaultValue)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseTimeParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		key      string
+		expected *time.Time
+	}{
+		{
+			name:  "valid time",
+			query: "time=2023-01-01T12:00:00Z",
+			key:   "time",
+			expected: func() *time.Time {
+				t, _ := time.Parse(time.RFC3339, "2023-01-01T12:00:00Z")
+				return &t
+			}(),
+		},
+		{
+			name:     "invalid time",
+			query:    "time=invalid",
+			key:      "time",
+			expected: nil,
+		},
+		{
+			name:     "missing key",
+			query:    "other=2023-01-01T12:00:00Z",
+			key:      "time",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{
+				URL: &url.URL{
+					RawQuery: tt.query,
+				},
+			}
+			result := ParseTimeParam(req, tt.key)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Implemented ParseQueryInt and ParseTimeParam functions for extracting integer and time parameters from HTTP requests.
- Added comprehensive unit tests for both functions to ensure correct behavior with various input scenarios.
- Included error handling for invalid and missing parameters.