### PR TITLE
feat(mixins): add TranslationMixin for handling locale and parent field indexing

### DIFF
--- a/ent/mixins/translation.go
+++ b/ent/mixins/translation.go
@@ -1,0 +1,35 @@
+package mixins
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
+	"entgo.io/ent/schema/mixin"
+)
+
+type TranslationMixin struct {
+	mixin.Schema
+	ParentField string
+}
+
+func (TranslationMixin) Fields() []ent.Field {
+	return []ent.Field{
+		field.String("locale").
+			NotEmpty().
+			Comment("IETF language tag, e.g. en, de, fr-FR"),
+	}
+}
+
+func (m TranslationMixin) Indexes() []ent.Index {
+	indexes := []ent.Index{
+		index.Fields("locale"),
+	}
+
+	if m.ParentField != "" {
+		indexes = append(indexes,
+			index.Fields("locale", m.ParentField).Unique(),
+		)
+	}
+
+	return indexes
+}

--- a/ent/mixins/translation.go
+++ b/ent/mixins/translation.go
@@ -1,3 +1,6 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
 package mixins
 
 import (


### PR DESCRIPTION
- Introduced TranslationMixin to manage locale as an IETF language tag.
- Implemented fields and indexes for the mixin, allowing for unique indexing based on locale and an optional parent field.
- Added comments for clarity on field usage.