### PR TITLE
feat(fga): update Entity.String method to handle wildcard entities

### DIFF
--- a/fga/types.go
+++ b/fga/types.go
@@ -54,8 +54,12 @@ type Entity struct {
 // If no Relation is specified, returns "<kind>:<identifier>"
 // If a Relation is specified, returns "<kind>:<identifier>#<relation>"
 func (e Entity) String() string {
+	if e.Kind == "*" && e.Identifier == "*" {
+		return "*"
+	}
+
 	if e.Kind == "" && e.Identifier == "" {
-		return ":"
+		return ""
 	}
 
 	if e.Relation == "" {

--- a/fga/types_test.go
+++ b/fga/types_test.go
@@ -110,7 +110,15 @@ func TestEntity_String(t *testing.T) {
 				Kind:       "",
 				Identifier: "",
 			},
-			expected: ":",
+			expected: "",
+		},
+		{
+			name: "wildcard entity",
+			entity: fga.Entity{
+				Kind:       "*",
+				Identifier: "*",
+			},
+			expected: "*",
 		},
 	}
 


### PR DESCRIPTION
- Modified the String method to return "*" for wildcard entities (Kind: "*", Identifier: "*").
- Adjusted the expected output in the corresponding test case to reflect this change.