### PR TITLE
feat(auth): Add AuthenticationMethodsReferences and constants for RFC8176 compliance

### DIFF
--- a/iam/auth/amr.go
+++ b/iam/auth/amr.go
@@ -1,0 +1,98 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth
+
+type AuthenticationMethodsReferences struct {
+	KnowledgeBasedAuthentication bool
+	UsernameAndPassword          bool
+	TOTP                         bool
+	Duo                          bool
+	WebAuthn                     bool
+	WebAuthnHardware             bool
+	WebAuthnSoftware             bool
+	WebAuthnUserPresence         bool
+	WebAuthnUserVerified         bool
+}
+
+// FactorKnowledge returns true if a "something you know" factor of authentication was used.
+func (r AuthenticationMethodsReferences) FactorKnowledge() bool {
+	return r.UsernameAndPassword || r.KnowledgeBasedAuthentication
+}
+
+// FactorPossession returns true if a "something you have" factor of authentication was used.
+func (r AuthenticationMethodsReferences) FactorPossession() bool {
+	return r.TOTP || r.Duo || r.WebAuthn || r.WebAuthnHardware || r.WebAuthnSoftware
+}
+
+// MultiFactorAuthentication returns true if multiple factors were used.
+func (r AuthenticationMethodsReferences) MultiFactorAuthentication() bool {
+	return r.FactorKnowledge() && r.FactorPossession()
+}
+
+// ChannelBrowser returns true if a browser was used to authenticate.
+func (r AuthenticationMethodsReferences) ChannelBrowser() bool {
+	return r.UsernameAndPassword || r.TOTP || r.WebAuthn || r.WebAuthnHardware || r.WebAuthnSoftware
+}
+
+// ChannelService returns true if a non-browser service was used to authenticate.
+func (r AuthenticationMethodsReferences) ChannelService() bool {
+	return r.Duo
+}
+
+// MultiChannelAuthentication returns true if the user used more than one channel to authenticate.
+func (r AuthenticationMethodsReferences) MultiChannelAuthentication() bool {
+	return r.ChannelBrowser() && r.ChannelService()
+}
+
+// MarshalRFC8176 returns the AMR claim slice of strings in the RFC8176 format.
+// https://datatracker.ietf.org/doc/html/rfc8176
+func (r AuthenticationMethodsReferences) MarshalRFC8176() []string {
+	var amr []string
+
+	if r.UsernameAndPassword {
+		amr = append(amr, AMRPasswordBasedAuthentication)
+	}
+
+	if r.KnowledgeBasedAuthentication {
+		amr = append(amr, AMRKnowledgeBasedAuthentication)
+	}
+
+	if r.TOTP {
+		amr = append(amr, AMROneTimePassword)
+	}
+
+	if r.Duo {
+		amr = append(amr, AMRShortMessageService)
+	}
+
+	if r.WebAuthn || r.WebAuthnHardware || r.WebAuthnSoftware {
+		amr = append(amr, AMRProofOfPossession)
+	}
+
+	if r.WebAuthnHardware {
+		amr = append(amr, AMRHardwareSecuredKey)
+	}
+
+	if r.WebAuthnSoftware {
+		amr = append(amr, AMRSoftwareSecuredKey)
+	}
+
+	if r.WebAuthnUserPresence {
+		amr = append(amr, AMRUserPresence)
+	}
+
+	if r.WebAuthnUserVerified {
+		amr = append(amr, AMRPersonalIdentificationNumber)
+	}
+
+	if r.MultiFactorAuthentication() {
+		amr = append(amr, AMRMultiFactorAuthentication)
+	}
+
+	if r.MultiChannelAuthentication() {
+		amr = append(amr, AMRMultiChannelAuthentication)
+	}
+
+	return amr
+}

--- a/iam/auth/const.go
+++ b/iam/auth/const.go
@@ -1,0 +1,115 @@
+// Copyright (c) Kopexa GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth
+
+// Authentication Method Reference Values https://datatracker.ietf.org/doc/html/rfc8176
+const (
+	// AMRKnowledgeBasedAuthentication is an RFC8176 Authentication Method Reference Value that represents
+	// knowledge-based authentication [NIST.800-63-2] [ISO29115].
+	AMRKnowledgeBasedAuthentication = "kba"
+
+	// AMRMultiFactorAuthentication is an RFC8176 Authentication Method Reference Value that represents multiple-factor
+	// authentication as per NIST.800-63-2 and ISO29115. When this is present, specific authentication methods used may
+	// also be included.
+	//
+	// Kopexa utilizes this when a user has performed any 2 AMR's with different factor values (excluding meta).
+	// Factor: Meta, Channel: Meta.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	//
+	// NIST.800-63-2: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf
+	//
+	// ISO29115: https://www.iso.org/standard/45138.html
+	AMRMultiFactorAuthentication = "mfa"
+
+	// AMRMultiChannelAuthentication is an RFC8176 Authentication Method Reference Value that represents
+	// multiple-channel authentication. The authentication involves communication over more than one distinct
+	// communication channel. For instance, a multiple-channel authentication might involve both entering information
+	// into a workstation's browser and providing information on a telephone call to a pre-registered number.
+	//
+	// Kopexa utilizes this when a user has performed any 2 AMR's with different channel values (excluding meta).
+	// Factor: Meta, Channel: Meta.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	AMRMultiChannelAuthentication = "mca"
+
+	// AMRUserPresence is an RFC8176 Authentication Method Reference Value that represents authentication that included
+	// a user presence test. Evidence that the end user is present and interacting with the device. This is sometimes
+	// also referred to as "test of user presence" as per W3C.WD-webauthn-20170216.
+	//
+	// Kopexa utilizes this when a user has used WebAuthn to authenticate and the user presence flag was set.
+	// Factor: Meta, Channel: Meta.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	//
+	// W3C.WD-webauthn-20170216: https://datatracker.ietf.org/doc/html/rfc8176#ref-W3C.WD-webauthn-20170216
+	AMRUserPresence = "user"
+
+	// AMRPersonalIdentificationNumber is an RFC8176 Authentication Method Reference Value that represents
+	// authentication that included a personal Identification Number (PIN) as per RFC4949 or pattern (not restricted to
+	// containing only numbers) that a user enters to unlock a key on the device. This mechanism should have a way to
+	// deter an attacker from obtaining the PIN by trying repeated guesses.
+	//
+	// Kopexa utilizes this when a user has used WebAuthn to authenticate and the user verified flag was set.
+	//	Factor: Meta, Channel: Meta.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	//
+	// RFC4949: https://datatracker.ietf.org/doc/html/rfc4949
+	AMRPersonalIdentificationNumber = "pin"
+
+	// AMRPasswordBasedAuthentication is an RFC8176 Authentication Method Reference Value that represents password-based
+	// authentication as per RFC4949.
+	//
+	// Kopexa utilizes this when a user has performed 1FA. Factor: Know, Channel: Browser.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	//
+	// RFC4949: https://datatracker.ietf.org/doc/html/rfc4949
+	AMRPasswordBasedAuthentication = "pwd"
+
+	// AMROneTimePassword is an RFC8176 Authentication Method Reference Value that represents authentication via a
+	// Time-based One-Time Password as per RFC4949. One-time password specifications that this authentication method
+	// applies to include RFC4226 and RFC6238.
+	//
+	// Kopexa utilizes this when a user has used TOTP to authenticate. Factor: Have, Channel: Browser.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	//
+	// RFC4949: https://datatracker.ietf.org/doc/html/rfc4949
+	//
+	// RFC4226: https://datatracker.ietf.org/doc/html/rfc4226
+	//
+	// RFC6238: https://datatracker.ietf.org/doc/html/rfc6238
+	AMROneTimePassword = "otp"
+
+	// AMRProofOfPossession is an Authentication Method Reference Value that
+	// represents authentication via a proof-of-Possession (PoP) of a software-secured (swk) or hardware-secured (hwk)
+	// key.
+	AMRProofOfPossession = "pop"
+
+	// AMRHardwareSecuredKey is an RFC8176 Authentication Method Reference Value that
+	// represents authentication via a proof-of-Possession (PoP) of a hardware-secured key.
+	//
+	// Kopexa utilizes this when a user has used WebAuthn to authenticate. Factor: Have, Channel: Browser.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	AMRHardwareSecuredKey = "hwk"
+
+	// AMRSoftwareSecuredKey is an RFC8176 Authentication Method Reference Value that
+	// represents authentication via a proof-of-Possession (PoP) of a software-secured key.
+	//
+	// Kopexa utilizes this when a user has used WebAuthn to authenticate. Factor: Have, Channel: Browser.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	AMRSoftwareSecuredKey = "swk"
+
+	// AMRShortMessageService is an RFC8176 Authentication Method Reference Value that
+	// represents authentication via confirmation using SMS text message to the user at a registered number.
+	//
+	// Kopexa utilizes this when a user has used Duo to authenticate. Factor: Have, Channel: Browser.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	AMRShortMessageService = "sms"
+)


### PR DESCRIPTION
- Introduced AuthenticationMethodsReferences struct with methods to determine authentication factors.
- Added constants for various authentication method reference values as per RFC8176.